### PR TITLE
fix: Bump kafka from 2.5.0 to 2.7.0 and testcontainer from 1.14.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,8 @@
 buildscript {
   ext {
     confluentVersion = '5.5.1'
-    kafkaVersion = '2.5.0'
-    tcVersion = '1.14.3'
+    kafkaVersion = '2.7.0'
+    tcVersion = '1.15.1'
   }
   repositories {
     jcenter()

--- a/src/main/java/io/confluent/testcontainers/SchemaRegistryContainer.java
+++ b/src/main/java/io/confluent/testcontainers/SchemaRegistryContainer.java
@@ -1,5 +1,7 @@
 package io.confluent.testcontainers;
 
+import static org.testcontainers.utility.DockerImageName.parse;
+
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.KafkaContainer;
 import org.testcontainers.containers.Network;
@@ -13,7 +15,7 @@ import org.testcontainers.containers.Network;
 public class SchemaRegistryContainer extends GenericContainer<SchemaRegistryContainer> {
 
   public SchemaRegistryContainer(String version) {
-    super("confluentinc/cp-schema-registry:" + version);
+    super(parse("confluentinc/cp-schema-registry:" + version));
     withExposedPorts(8081);
   }
 

--- a/src/test/java/io/confluent/testcontainers/AvroProducerConsumerTest.java
+++ b/src/test/java/io/confluent/testcontainers/AvroProducerConsumerTest.java
@@ -1,5 +1,8 @@
 package io.confluent.testcontainers;
 
+import static io.confluent.testcontainers.Constants.KAFKA_IMAGE_TAG;
+import static io.confluent.testcontainers.Constants.KAFKA_TEST_IMAGE;
+
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -14,15 +17,16 @@ import io.confluent.developer.Movie;
 import io.confluent.testcontainers.support.TestAvroConsumer;
 import io.confluent.testcontainers.support.TestAvroProducer;
 import lombok.extern.slf4j.Slf4j;
+import org.testcontainers.utility.DockerImageName;
 
 @Slf4j
 public class AvroProducerConsumerTest {
 
-  public static KafkaContainer kafka = new KafkaContainer("5.5.1")
+  public static KafkaContainer kafka = new KafkaContainer(DockerImageName.parse(KAFKA_TEST_IMAGE))
       .withLogConsumer(new Slf4jLogConsumer(log))
       .withNetwork(Network.newNetwork());
 
-  public static SchemaRegistryContainer schemaRegistry = new SchemaRegistryContainer("5.5.1")
+  public static SchemaRegistryContainer schemaRegistry = new SchemaRegistryContainer(KAFKA_IMAGE_TAG)
       .withLogConsumer(new Slf4jLogConsumer(log));
 
   @BeforeClass

--- a/src/test/java/io/confluent/testcontainers/Constants.java
+++ b/src/test/java/io/confluent/testcontainers/Constants.java
@@ -1,0 +1,12 @@
+package io.confluent.testcontainers;
+
+public final class Constants {
+
+  private Constants() {
+  }
+
+  public static final String KAFKA_IMAGE_TAG = "5.5.3";
+  public static final String KAFKA_TEST_IMAGE = "confluentinc/cp-kafka:" + KAFKA_IMAGE_TAG;
+  public static final String SCHEMA_REGISTRY_TEST_IMAGE = "confluentinc/cp-schema-registry:" + KAFKA_IMAGE_TAG;
+
+}

--- a/src/test/java/io/confluent/testcontainers/CpKsqlDbServerContainerTest.java
+++ b/src/test/java/io/confluent/testcontainers/CpKsqlDbServerContainerTest.java
@@ -19,20 +19,22 @@ import io.restassured.path.json.JsonPath;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 
+import static io.confluent.testcontainers.Constants.KAFKA_TEST_IMAGE;
 import static io.confluent.testcontainers.CpKsqlDbServerContainer.KSQL_REQUEST_CONTENT_TYPE;
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.testcontainers.utility.DockerImageName.parse;
 
 @Slf4j
 public class CpKsqlDbServerContainerTest extends AbstractKsqlServerContainerTest {
 
-  private static final KafkaContainer kafka = new KafkaContainer("5.5.1").withNetwork(Network.newNetwork());
+  private static final KafkaContainer kafka = new KafkaContainer(parse(KAFKA_TEST_IMAGE)).withNetwork(Network.newNetwork());
   private static final SchemaRegistryContainer schemaRegistry = new SchemaRegistryContainer("5.5.1");
 
   @BeforeClass
   public static void setUpClass() {
-    // for ksql command topic 
+    // for ksql command topic
     kafka.addEnv("KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR", "1");
     kafka.addEnv("KAFKA_TRANSACTION_STATE_LOG_MIN_ISR", "1");
     kafka.addEnv("KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR", "1");
@@ -130,7 +132,7 @@ public class CpKsqlDbServerContainerTest extends AbstractKsqlServerContainerTest
 
       /*
         a response from ksqlDB server looks like
-       
+
         [
           {
             "@type": "streams",

--- a/src/test/java/io/confluent/testcontainers/KsqlDbServerContainerTest.java
+++ b/src/test/java/io/confluent/testcontainers/KsqlDbServerContainerTest.java
@@ -1,5 +1,8 @@
 package io.confluent.testcontainers;
 
+import static io.confluent.testcontainers.Constants.KAFKA_TEST_IMAGE;
+import static org.testcontainers.utility.DockerImageName.parse;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -14,12 +17,14 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class KsqlDbServerContainerTest extends AbstractKsqlServerContainerTest {
 
-  private static final KafkaContainer kafka = new KafkaContainer("5.5.1").withNetwork(Network.newNetwork());
+  private static final KafkaContainer kafka = new KafkaContainer(parse(KAFKA_TEST_IMAGE))
+      .withNetwork(Network.newNetwork());
+
   private static final SchemaRegistryContainer schemaRegistry = new SchemaRegistryContainer("5.5.1");
 
   @BeforeClass
   public static void setUpClass() {
-    // for ksql command topic 
+    // for ksql command topic
     kafka.addEnv("KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR", "1");
     kafka.addEnv("KAFKA_TRANSACTION_STATE_LOG_MIN_ISR", "1");
     kafka.addEnv("KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR", "1");

--- a/src/test/java/io/confluent/testcontainers/ProducerConsumerTest.java
+++ b/src/test/java/io/confluent/testcontainers/ProducerConsumerTest.java
@@ -1,5 +1,8 @@
 package io.confluent.testcontainers;
 
+import static io.confluent.testcontainers.Constants.KAFKA_TEST_IMAGE;
+import static org.testcontainers.utility.DockerImageName.parse;
+
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.junit.Assert;
 import org.junit.ClassRule;
@@ -17,7 +20,7 @@ import lombok.extern.slf4j.Slf4j;
 public class ProducerConsumerTest {
 
   @ClassRule
-  public static KafkaContainer kafka = new KafkaContainer("5.5.1")
+  public static KafkaContainer kafka = new KafkaContainer(parse(KAFKA_TEST_IMAGE))
       .withLogConsumer(new Slf4jLogConsumer(log));
 
   @Test

--- a/src/test/java/io/confluent/testcontainers/ProducerTransactionTest.java
+++ b/src/test/java/io/confluent/testcontainers/ProducerTransactionTest.java
@@ -12,16 +12,18 @@ import java.util.Properties;
 
 import lombok.extern.slf4j.Slf4j;
 
+import static io.confluent.testcontainers.Constants.KAFKA_TEST_IMAGE;
 import static org.apache.kafka.clients.consumer.ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG;
 import static org.apache.kafka.clients.producer.ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG;
 import static org.apache.kafka.clients.producer.ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG;
 import static org.apache.kafka.clients.producer.ProducerConfig.TRANSACTIONAL_ID_CONFIG;
 import static org.apache.kafka.clients.producer.ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG;
+import static org.testcontainers.utility.DockerImageName.parse;
 
 @Slf4j
 public class ProducerTransactionTest {
 
-  public static KafkaContainer kafka = new KafkaContainer("5.5.1")
+  public static KafkaContainer kafka = new KafkaContainer(parse(KAFKA_TEST_IMAGE))
       .withLogConsumer(new Slf4jLogConsumer(log));
 
   @BeforeClass

--- a/src/test/java/io/confluent/testcontainers/SchemaRegistryContainerTest.java
+++ b/src/test/java/io/confluent/testcontainers/SchemaRegistryContainerTest.java
@@ -1,8 +1,13 @@
 package io.confluent.testcontainers;
 
+import static io.confluent.testcontainers.Constants.KAFKA_IMAGE_TAG;
+import static io.confluent.testcontainers.Constants.KAFKA_TEST_IMAGE;
+import static org.testcontainers.utility.DockerImageName.parse;
+
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.testcontainers.containers.KafkaContainer;
+import org.testcontainers.containers.Network;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.containers.wait.strategy.Wait;
 
@@ -11,7 +16,10 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class SchemaRegistryContainerTest {
 
-  private static final KafkaContainer kafka = new KafkaContainer("5.5.1");
+  private static final KafkaContainer kafka = new KafkaContainer(parse(KAFKA_TEST_IMAGE))
+      .withNetwork(Network.newNetwork());
+
+
 
   @BeforeClass
   public static void setUp() {
@@ -20,7 +28,7 @@ public class SchemaRegistryContainerTest {
 
   @Test
   public void shouldStartWithKafka() {
-    try (SchemaRegistryContainer schemaRegistryContainer = new SchemaRegistryContainer("5.5.1")) {
+    try (SchemaRegistryContainer schemaRegistryContainer = new SchemaRegistryContainer(KAFKA_IMAGE_TAG)) {
       schemaRegistryContainer.withKafka(kafka)
           .withLogConsumer(new Slf4jLogConsumer(log))
           .waitingFor(Wait.forHttp("/subjects")


### PR DESCRIPTION
Bump kafka from 2.5.0 to 2.7.0 and testcontainer from 1.14.3 and use kafka image 5.5.3 + some fixes

Signed-off-by: jpiraguha <jiraguha@gmail.com>